### PR TITLE
Update No More Heroes III CUSA32167 01.03 SHN

### DIFF
--- a/shn/CUSA32167_01.03.shn
+++ b/shn/CUSA32167_01.03.shn
@@ -2,20 +2,6 @@
 <Trainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Game="No More Heroes III" Moder="Skal" Cusa="CUSA32167" Version="01.03" Process="eboot.bin">
   <Genres Name="Action" />
   <Items />
-  <Cheat Text="1 Hit Kill + Godmode" Description="What/how/when is this Cheat: Change me!">
-    <Cheatline>
-      <Section>0</Section>
-      <Offset>64CB800</Offset>
-      <ValueOn>49-83-F8-0A-74-2E-49-83-F8-08-74-28-49-83-F8-00-74-22-49-83-F8-20-74-0B-89-B7-64-0A-00-00-E9-B7-A0-8B-FA-31-C0-31-D2-31-F6-89-B7-64-0A-00-00-E9-A6-A0-8B-FA-89-C8-89-CA-89-CE-89-B7-64-0A-00-00-E9-95-A0-8B-FA</ValueOn>
-      <ValueOff>00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00</ValueOff>
-    </Cheatline>
-    <Cheatline>
-      <Section>0</Section>
-      <Offset>D858D4</Offset>
-      <ValueOn>E9-27-5F-74-05-90</ValueOn>
-      <ValueOff>89-B7-64-0A-00-00</ValueOff>
-    </Cheatline>
-  </Cheat>
   <Cheat Text="Sword battery never decreases" Description="What/how/when is this Cheat: Change me!">
     <Cheatline>
       <Section>0</Section>


### PR DESCRIPTION
Removes the 1 Hit kill temporarily since Max Uc on gain is code caved on the same spot... Dxwatch amirite?...

I will Re-add the 1 hit kill soon. But this should be merged to prevent ps4s from crashing unnecessarily. 