### PR TITLE
update cheat persona 5 royal

### DIFF
--- a/json/CUSA17419_01.01.json
+++ b/json/CUSA17419_01.01.json
@@ -70,12 +70,12 @@
       ]
     },
     {
-      "name": "99 item",
+      "name": "90 item",
       "type": "checkbox",
       "memory": [
         {
           "offset": "EBC37C",
-          "on": "B26390",
+          "on": "B25A90",
           "off": "0F42D6"
         }
       ]


### PR DESCRIPTION
update item 99 in box to item 90 in box, some missions are buggy if you have 99 active as you cannot create items due to lack of space in the item box