### PR TITLE
Update CUSA07023_01.03.json

### DIFF
--- a/json/CUSA07023_01.03.json
+++ b/json/CUSA07023_01.03.json
@@ -10,12 +10,12 @@
       "type": "checkbox",
       "memory": [
         {
-          "offset": "450759",
+          "offset": "50759",
           "on": "C683EC000000FF",
           "off": "488983EC000000"
         },
         {
-          "offset": "4A5975",
+          "offset": "A5975",
           "on": "66C783EC000000E703909090",
           "off": "8B88B4030000018BEC000000"
         }
@@ -27,7 +27,7 @@
       "type": "checkbox",
       "memory": [
         {
-          "offset": "4AA374",
+          "offset": "AA374",
           "on": "909090909090",
           "off": "8983F8000000"
         }
@@ -39,7 +39,7 @@
       "type": "checkbox",
       "memory": [
         {
-          "offset": "A4415C",
+          "offset": "64415C",
           "on": "01",
           "off": "02"
         }
@@ -51,7 +51,7 @@
       "type": "button",
       "memory": [
         {
-          "offset": "A4415C",
+          "offset": "64415C",
           "on": "03",
           "off": "03"
         }
@@ -63,7 +63,7 @@
       "type": "button",
       "memory": [
         {
-          "offset": "A44180",
+          "offset": "644180",
           "on": "00000F0000400000",
           "off": "00000F0000400000"
         }
@@ -75,7 +75,7 @@
       "type": "button",
       "memory": [
         {
-          "offset": "200036604",
+          "offset": "1FFC36604",
           "on": "20",
           "off": "20"
         }


### PR DESCRIPTION
I tested this one and it didn't work on the shadps4 emulator, but in this other repository there is the same cheat from the same author "Talixme", the values ​​are different and it worked for me.
https://wolf2022.ir/trainer/CUSA07023_01.03.json

As you can see, it was previously correct, and a change was made:
https://github.com/GoldHEN/GoldHEN_Cheat_Repository/commit/bacc7c3a8797594b33ba112faafcf3fde000e0f1#diff-407957fbf0502b718efb9750bc4e33e066e9cdec2087f1569d426741afe1cac4R13
Why were there several changes made to the commit?